### PR TITLE
Simply adds Plausible into the head tag.

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -17,6 +17,15 @@ const config: Config = {
   baseUrl: "/",
   favicon: "img/favicon.png",
 
+  // Plausible Analytics
+  scripts: [
+    {
+      src: "https://plausible.source.network/js/script.js",
+      defer: true,
+      "data-domain": "docs.shinzo.network",
+    },
+  ],
+
   // Future flags, see https://docusaurus.io/docs/api/docusaurus-config#future
   future: {
     v4: true,

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -77,7 +77,6 @@ const config: Config = {
       defaultMode: "light",
     },
     navbar: {
-      title: null,
       hideOnScroll: false,
       logo: {
         alt: "Shinzo Network Documentation",


### PR DESCRIPTION
Could've hardcoded it in, but it's easier to throw it into this config instead. Also fixes a teeny weeny typescript error by removing an unused `title` field from the docusaurus config.

Closes #88.