### PR TITLE
Temporarily disables dark-mode for now.

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -75,6 +75,7 @@ const config: Config = {
     colorMode: {
       respectPrefersColorScheme: false,
       defaultMode: "light",
+      disableSwitch: true, // TEMPORARY: dark mode toggle disabled
     },
     navbar: {
       hideOnScroll: false,


### PR DESCRIPTION
We'll bring it back once I've figured out how to deal with Docusaurus showing light/dark images based on browser theme.

Closes #121.