### PR TITLE
Clarifies that Indexers are not RPC nodes.

### DIFF
--- a/content/indexer/faq.md
+++ b/content/indexer/faq.md
@@ -9,9 +9,13 @@ description: Frequently Asked Questions for Indexer
 
 https://github.com/shinzonetwork/shinzo-indexer-client
 
+### Does the indexer replace my Ethereum node?
+
+No. The indexer is a sidecar client that reads from an existing Ethereum execution node (Geth, Reth, Nethermind, Erigon, or a managed provider). It does not run an execution client, does not serve JSON-RPC, and is not a substitute for your validator's node. You point it at an upstream RPC and WebSocket endpoint, and it ingests block data from there into its local DefraDB.
+
 ### What hardware is recommended for deploying Shinzo?
 
-Shinzo is lightweight in terms of CPU usage, but **storage performance and host stability are critical** for reliable operation. Based on current production usage:
+Shinzo is lightweight on CPU, but storage performance and host stability matter for reliable operation. Based on current production usage:
 
 | Component | Minimum | Recommended |
 | --- | --- | --- |
@@ -20,26 +24,25 @@ Shinzo is lightweight in terms of CPU usage, but **storage performance and host 
 | Storage | 3 TB NVMe | 4+ TB NVMe |
 | OS | Ubuntu 24.04 | Ubuntu 24.04 |
 
-### Which RPC methods are supported?
+### Which RPC methods does the indexer call on the upstream node?
 
-To ingest data from an EVM chain, the connected RPC node must support the following methods:
+The indexer reads from whatever execution node you point it at. That upstream node must support these methods:
 
-- `eth_getTransactionReceipt` **(required)**
-- `eth_getBlockByNumber` **(required)**
+- `eth_getTransactionReceipt` (required)
+- `eth_getBlockByNumber` (required)
 - `eth_getLogs`
 - `eth_call`
 - `eth_getBlockByHash`
 - `net_version`
 - `net_peers`
 - `eth_getUncleByBlockHashAndIndex`
-- `eth_getBlockByNumber`
 - `eth_getBlockReceipts`
 
-> Note: The indexer only actively uses `eth_getBlockByNumber` and `eth_getTransactionReceipt` to ingest data but all listed methods are supported for compatibility.
+> Note: The indexer only actively calls `eth_getBlockByNumber` and `eth_getTransactionReceipt` to ingest data. The other methods are listed for compatibility.
 
 ### What types of data are indexed?
 
-All blockchain data is indexed, including blocks, transactions, logs, and storage access lists. The data is indexed by **hash [block + transaction]**, **block number**, and **document**.
+All blockchain data is indexed, including blocks, transactions, logs, and storage access lists. The data is indexed by hash (block and transaction), block number, and document.
 
 ### How much space do I need?
 
@@ -57,7 +60,7 @@ The further back you choose, the longer it will take to get to current blocks. H
 
 ### How often is the indexer updated with new blocks?
 
-The indexer fetches blocks directly by block number from its connected validator or RPC node. As soon as a block becomes available via RPC after being gossiped and finalized on the network, it can be indexed.
+The indexer fetches blocks by block number from the upstream Ethereum node it is configured to read from. As soon as a block becomes available on that node after being gossiped and finalized on the network, the indexer can pull it in. The indexer does not participate in consensus or gossip itself; it just reads from a node that does.
 
 ### How does storage grow over time?
 

--- a/content/indexer/overview.md
+++ b/content/indexer/overview.md
@@ -7,11 +7,7 @@ description: Introduction to the Shinzo Indexer
 
 The Shinzo Indexer is a lightweight sidecar that runs alongside an existing Ethereum execution client and reads from it. It pulls block data out of the node and writes it into a local DefraDB in a shape that is easy to query.
 
-:::info[The indexer is not an RPC node.]
-It does not replace Geth, Reth, Nethermind, or any other execution client, and it does not serve JSON-RPC traffic to applications.
-:::
-
-Instead, the indexer consumes upstream RPC and WebSocket endpoints from a node you already have access to: a local execution client, a node co-located with your validator, or a managed provider. It transforms the raw chain data those endpoints return into structured, relationally linked documents stored in its local DefraDB instance.
+The indexer is **not** an RPC node. It does not replace Geth, Reth, Nethermind, or any other execution client, and it does not serve JSON-RPC traffic to applications. Instead, the indexer consumes upstream RPC and WebSocket endpoints from a node you already have access to: a local execution client, a node co-located with your validator, or a managed provider. It transforms the raw chain data those endpoints return into structured, relationally linked documents stored in its local DefraDB instance.
 
 ## Purpose and role in the stack
 

--- a/content/indexer/overview.md
+++ b/content/indexer/overview.md
@@ -5,50 +5,54 @@ sidebar_position: 1
 description: Introduction to the Shinzo Indexer
 ---
 
-The Shinzo Indexer is a high-performance, fault-tolerant blockchain indexing engine designed for deterministic, query-friendly extraction of Ethereum data. It sits between an Ethereum execution node and downstream applications, transforming raw chain data into structured, relationally linked documents stored in DefraDB, all while maintaining strong guarantees around consistency, concurrency, and observability.
+The Shinzo Indexer is a lightweight sidecar that runs alongside an existing Ethereum execution client and reads from it. It pulls block data out of the node and writes it into a local DefraDB in a shape that is easy to query.
 
-## Purpose and Role in the Stack
+The indexer is not an RPC node. It does not replace Geth, Reth, Nethermind, or any other execution client, and it does not serve JSON-RPC traffic to applications.
 
-At its core, the indexer continuously consumes blocks, transactions, logs, and EIP-2930 access lists from an Ethereum node and normalizes them into a strongly-typed data model. It exposes this indexed data through Peer-2-Peer Network powered by DefraDB, enabling downstream services to query block-level and transaction-level information without depending directly on JSON-RPC. This separates data access from blockchain node operations, enabling stateless microservices, cheaper infra, and deterministic historical queries.
+Instead, the indexer consumes upstream RPC and WebSocket endpoints from a node you already have access to: a local execution client, a node co-located with your validator, or a managed provider. It transforms the raw chain data those endpoints return into structured, relationally linked documents stored in its local DefraDB instance.
 
-## Architecture Overview
+## Purpose and role in the stack
 
-### 1. Indexer Engine (Go)
+The indexer continuously pulls blocks, transactions, logs, and EIP-2930 access lists from whichever upstream Ethereum node you point it at, then normalizes them into a strongly-typed data model. It exposes this indexed data through a peer-to-peer network powered by DefraDB, so downstream services can query block-level and transaction-level information without going through JSON-RPC themselves. The execution client still does the work of being an execution client. The indexer just reads from it and reshapes the data for query.
 
-The core indexing engine is written in Go and handles concurrent block processing. It connects to managed blockchain nodes via dual WebSocket/HTTP connections and ensures deterministic document IDs, duplicate block protection, and graceful shutdown handling.
+## Architecture overview
 
-### 2. Current Supported Chains
+### Indexer engine (Go)
 
-Supports connections to Ethereum Mainnet currently through a Geth client using JSON-RPC and WebSocket endpoints. Handles network-level errors with retries and timeouts.
+The core indexing engine is written in Go and handles concurrent block processing. It connects to an upstream Ethereum node over HTTP and WebSocket, and provides deterministic document IDs, duplicate block protection, and graceful shutdown handling. The upstream node is supplied by you. The indexer does not run one.
 
-### 3. DefraDB
+### Currently supported chains
 
-Acts as the primary persistence layer, providing a P2P-ready, decentralized document store with GraphQL query capabilities. The indexer uses it to store:
+The indexer currently supports Ethereum Mainnet. It works with any execution client that exposes a standard Ethereum JSON-RPC and WebSocket interface (Geth, Reth, Nethermind, Erigon, or a managed provider). Network-level errors are handled with retries and timeouts.
 
-- Blocks
-- Transactions
-- Logs
-- AccessListEntries
-- Relationships between blockchain entities
+### DefraDB
 
-DefraDB provides queryable, P2P-ready storage, which aligns with Shinzo Network’s distributed architecture goals.
+DefraDB is the indexer's local persistence layer. It is a peer-to-peer document store with GraphQL query capabilities. The indexer writes the following into its local DefraDB instance:
 
-### 4. GraphQL API
+- Blocks.
+- Transactions.
+- Logs.
+- AccessListEntries.
+- Relationships between blockchain entities.
 
-DefraDB exposes all indexed blockchain data via GraphQL, enabling typed queries for both real-time and historical blockchain data.
+DefraDB provides the queryable, P2P-ready storage that the rest of the Shinzo Network reads from.
 
-### 5. Logging & Error System
+### GraphQL API
 
-- Uber Zap: global structured logging with context (block number, tx hash, etc.)
-- IndexerError System: typed errors (NetworkError, DataError, StorageError, SystemError) with severity levels, structured context, and smart retry logic
+DefraDB exposes the indexed data via GraphQL for typed queries against both real-time and historical data. This is the indexer's read interface; it is not an Ethereum JSON-RPC endpoint.
 
-### 6. Configuration Layer (Viper)
+### Logging and error system
+
+- Uber Zap for structured logging with context (block number, tx hash, etc.).
+- The IndexerError system: typed errors (NetworkError, DataError, StorageError, SystemError) with severity levels, structured context, and retry logic.
+
+### Configuration layer (Viper)
 
 YAML-based configuration with environment variable overrides for:
 
-- Ethereum node endpoints
-- DefraDB settings (P2P, keyring, embedded/remote)
-- Indexer start height
-- Logger configuration
+- Upstream Ethereum node endpoints (RPC and WebSocket URLs supplied by you).
+- DefraDB settings (P2P, keyring, embedded/remote).
+- Indexer start height.
+- Logger configuration.
 
-In summary, the Shinzo Indexer serves as a reliable bridge between Ethereum nodes and applications, providing structured, queryable blockchain data. Its design emphasizes concurrency, error handling, and observability, enabling developers to interact with consistent and deterministic data while keeping application logic decoupled from node operations.
+The Shinzo Indexer is a client that reads from an Ethereum node you already have and writes structured data into a local DefraDB. It does not replace your execution client, and it does not expose JSON-RPC. Applications query the normalized data instead of talking to the chain directly.

--- a/content/indexer/overview.md
+++ b/content/indexer/overview.md
@@ -7,7 +7,9 @@ description: Introduction to the Shinzo Indexer
 
 The Shinzo Indexer is a lightweight sidecar that runs alongside an existing Ethereum execution client and reads from it. It pulls block data out of the node and writes it into a local DefraDB in a shape that is easy to query.
 
-The indexer is not an RPC node. It does not replace Geth, Reth, Nethermind, or any other execution client, and it does not serve JSON-RPC traffic to applications.
+:::info[The indexer is not an RPC node.]
+It does not replace Geth, Reth, Nethermind, or any other execution client, and it does not serve JSON-RPC traffic to applications.
+:::
 
 Instead, the indexer consumes upstream RPC and WebSocket endpoints from a node you already have access to: a local execution client, a node co-located with your validator, or a managed provider. It transforms the raw chain data those endpoints return into structured, relationally linked documents stored in its local DefraDB instance.
 

--- a/content/indexer/quickstart.md
+++ b/content/indexer/quickstart.md
@@ -20,7 +20,7 @@ The indexer is not an RPC node. It does not replace your execution client (Geth,
 
 ## Prerequisites
 
-- Go 1.24 or higher. You can download the latest version from [the Go site](https://go.dev/doc/install).
+- Go 1.25 or higher. You can download the latest version from [the Go site](https://go.dev/doc/install).
 - Access to an Ethereum execution node that exposes JSON-RPC and WebSocket. The indexer does not run a node for you; it reads from one. This can be a node you run yourself, a node co-located with your validator, or a managed provider (GCP Managed Blockchain Node works well).
 - Metamask with a wallet setup. This wallet does not need to hold any funds.
 
@@ -105,7 +105,8 @@ DEFRADB_KEYRING_SECRET=<pick_a_password>
 INDEXER_START_HEIGHT=<pick_a_starting_block>
 ```
 
-:::tip Note
+:::tip 
+Note
 The indexer needs to know how to reach an upstream Ethereum execution node. It does not run one. The variables are named `GETH_*` for historical reasons, but they accept the RPC and WebSocket URL of any standard Ethereum execution client (Geth, Reth, Nethermind, Erigon) or managed provider.
 
 ```bash
@@ -127,7 +128,7 @@ If you plan to use the GraphQL API, open port `9181` as well. This is the indexe
 
 To run the indexer locally, you have two options.
 
-### Using Makefile (recommended)
+### Using Makefile
 
 ```bash
 # Build the indexer
@@ -152,7 +153,8 @@ Once you run `make start`, the client begins writing block data into the configu
 
 The indexer exposes an OpenAPI-compatible REST endpoint for basic health and operational checks at http://localhost:8080/health. This is for monitoring the indexer itself; it is not a JSON-RPC endpoint.
 
-:::tip Security recommendation
+:::tip 
+Security recommendation
 The GraphQL and REST endpoints are intended for local or private-network access only. Shinzo Hosts are the layer expected to expose public data, so you should not expose your indexer's APIs directly to the public internet. Use proper firewall rules or private networking when deploying in production.
 :::
 
@@ -162,10 +164,10 @@ To participate in the Shinzo Network, you must register your indexer. Registrati
 
 1. Start your indexer.
 1. Add Shinzo Devnet to Metamask with the following values:
-   - Network name: Shinzo.
-   - Default RPC URL: http://rpc.devnet.shinzo.network:8545.
-   - Chain ID: 91273002.
-   - Currency symbol: SHN.
+   - Network name: Shinzo
+   - Default RPC URL: http://rpc.devnet.shinzo.network:8545
+   - Chain ID: 91273002
+   - Currency symbol: SHN
 1. Open the [registration route](http://localhost:8080/registration-app), connect your wallet, and share your wallet address in the Shinzo Discord channel to request whitelisting as an Indexer.
 1. Once your address has been whitelisted, return to the registration page, click Register, and select "Indexer" as your role.
 1. Submit your registration, then confirm the transaction in MetaMask. You should see a successful registration notification.

--- a/content/indexer/quickstart.md
+++ b/content/indexer/quickstart.md
@@ -5,9 +5,11 @@ sidebar_position: 2
 description: Instructions for installing and running the Shinzo Indexer
 ---
 
-The **Shinzo Indexer** is the entry point into the Shinzo Network. The indexer is a client built with golang allowing a validator of any network to earn an additional reward for sorting and storing blocks with Shinzo.
+The Shinzo Indexer is the entry point into the Shinzo Network. It is a lightweight Go client that runs as a sidecar in your validator environment and reads from an Ethereum node you already operate or have access to.
 
-## Hardware Recommendations
+The indexer is not an RPC node. It does not replace your execution client (Geth, Reth, Nethermind, etc.), and it does not serve JSON-RPC. It consumes RPC and WebSocket endpoints from an upstream node, sorts the responses into the appropriate collection types, and writes them into a local DefraDB instance. Running the indexer lets a validator earn an additional reward for sorting and storing blocks with Shinzo.
+
+## Hardware recommendations
 
 | Component | Minimum | Recommended |
 | --- | --- | --- |
@@ -18,13 +20,13 @@ The **Shinzo Indexer** is the entry point into the Shinzo Network. The indexer i
 
 ## Prerequisites
 
-- Make sure to have minimum Go version 1.24 or higher. You can download the latest Go verion from [here](https://go.dev/doc/install).
-- Running Ethereum node with JSON-RPC and WebSocket access (GCP Managed Blockchain Node recommended).
+- Go 1.24 or higher. You can download the latest version from [the Go site](https://go.dev/doc/install).
+- Access to an Ethereum execution node that exposes JSON-RPC and WebSocket. The indexer does not run a node for you; it reads from one. This can be a node you run yourself, a node co-located with your validator, or a managed provider (GCP Managed Blockchain Node works well).
 - Metamask with a wallet setup. This wallet does not need to hold any funds.
 
-## One-Step Cloud Setup
+## One-step cloud setup
 
-You can run the indexer with the following commands. Be sure to replace **"&lt;YOUR_RPC_URL&gt;", "&lt;YOUR_WS_URL&gt;", and "&lt;YOUR_API_KEY&gt;"** before running.
+You can run the indexer with the following commands. Replace `<YOUR_RPC_URL>`, `<YOUR_WS_URL>`, and `<YOUR_API_KEY>` with the endpoints of the upstream Ethereum node you want the indexer to read from. These are not endpoints the indexer creates; they belong to your existing node or managed provider.
 
 
 ```bash
@@ -51,7 +53,7 @@ docker pull ghcr.io/shinzonetwork/shinzo-indexer-client:latest
 sudo docker run -d --network host --name shinzo-indexer   --restart unless-stopped   -e GETH_RPC_URL="<YOUR_RPC_URL>"   -e GETH_WS_URL="<YOUR_WS_URL>"   -e GETH_API_KEY="<YOUR_API_KEY>"   -e INDEXER_START_HEIGHT=23900000   -e DEFRADB_KEYRING_SECRET="pingpong"   -v /mnt/defradb-data:/app/.defra   -v /mnt/defradb-data/logs:/app/logs   -p 8080:8080   -p 9171:9171  ghcr.io/shinzonetwork/shinzo-indexer-client:latest
 ```
 
-To ensure this is running properly, you can test it by checking the metrics endpoint.
+Check that the container is running by hitting the metrics endpoint:
 
 ```bash
 curl http://localhost:8080/metrics
@@ -59,32 +61,36 @@ curl http://localhost:8080/metrics
 
 ## Installation
 
-0. If using Linux, install the native build toolchain:
+If you are on Linux, install the native build toolchain first:
 
 ```bash
 sudo apt-get update
 sudo apt-get install -y build-essential pkg-config
 ```
 
-1. Clone the repository:
+Then:
+
+1. Clone the repository.
+
+   ```bash
+   git clone https://github.com/shinzonetwork/shinzo-indexer-client.git
+   cd shinzo-indexer-client
+   ```
+
+1. Install Go dependencies.
+
+   ```bash
+   go mod download
+   ```
+
+1. Create a `.env` file with the environment variables below. The `GETH_*` values point at the upstream Ethereum node you want the indexer to read from; they are not endpoints the indexer creates.
 
 ```bash
-git clone https://github.com/shinzonetwork/shinzo-indexer-client.git
-cd shinzo-indexer-client
-```
-
-2. Install Go dependencies:
-
-```bash
-go mod download
-```
-
-3. Once all the dependencies are installed, create a `.env` file which will have all the environment variables. You can copy and paste the below content in your `.env` file
-
-```bash
-GETH_RPC_URL=<your-geth-node-url>
-GETH_WS_URL=<your-geth-ws-url>
-GETH_API_KEY=<your-geth-api-key>        # Optional only if Geth has authentication
+# Upstream Ethereum execution node the indexer reads from.
+# This is your own node or a managed provider. The indexer does not run one.
+GETH_RPC_URL=<your-upstream-rpc-url>
+GETH_WS_URL=<your-upstream-ws-url>
+GETH_API_KEY=<your-upstream-api-key>    # Optional, only if the upstream node requires authentication
 
 # DefraDB Configuration
 DEFRADB_URL=                            # Keep it empty for embedded DefraDB
@@ -100,30 +106,28 @@ INDEXER_START_HEIGHT=<pick_a_starting_block>
 ```
 
 :::tip Note
-The indexer requires the following GETH configuration values to run:
+The indexer needs to know how to reach an upstream Ethereum execution node. It does not run one. The variables are named `GETH_*` for historical reasons, but they accept the RPC and WebSocket URL of any standard Ethereum execution client (Geth, Reth, Nethermind, Erigon) or managed provider.
 
 ```bash
 GETH_RPC_URL=
 GETH_WS_URL=
-GETH_API_KEY= # optional if Geth has authentication
+GETH_API_KEY= # optional, only if your node requires authentication
 ```
 
-These three keys are necessary for the indexer to function. The indexer queries the Geth node for each block, sorts the data into the appropriate collection types, and stores it in its local Defra instance.
-If you are running Geth locally, use your local node's RPC and WebSocket URLs.
-If you are using a deployed or remote Geth node, replace these values with the correct endpoint URLs and API key (if authentication is required).
+For each new block, the indexer queries this upstream node, sorts the response into the appropriate collection types (blocks, transactions, logs, access list entries), and writes it to its local DefraDB. If you are running an execution client on the same machine, use that node's RPC and WebSocket URLs. If you are using a remote or managed node, use those endpoint URLs and the API key, if authentication is required.
 :::
 
-## Network Configuring
+## Network configuration
 
-The system uses P2P networking over port `9171`. Make sure this port is open and accessible in all production deployments.
+The indexer uses P2P networking over port `9171`. Make sure this port is open and accessible in all production deployments.
 
-Optional: If you plan to use the GraphQL API, open port `9181` as well.
+If you plan to use the GraphQL API, open port `9181` as well. This is the indexer's read interface, not an Ethereum JSON-RPC endpoint.
 
-## Running Locally
+## Running locally
 
-To run the indexer locally, we have two options:
+To run the indexer locally, you have two options.
 
-### Using Makefile (Recommended)
+### Using Makefile (recommended)
 
 ```bash
 # Build the indexer
@@ -140,35 +144,34 @@ make start
 docker-compose up --build
 ```
 
-Once you start the client using `make start` command, it will begin submitting block data to the configured DefraDB instance.
+Once you run `make start`, the client begins writing block data into the configured DefraDB instance.
 
-> Running `make stop` command will shut down the client and DefraDB and all data will be saved to the configured storage location.
+`make stop` shuts down the client and DefraDB. Data is saved to the configured storage location.
 
-**OpenAPI / REST API**
+### OpenAPI and REST endpoint
 
-The indexer also exposes an OpenAPI-compatible REST endpoint for basic health and operational checks, which you can visit here: http://localhost:8080/health
+The indexer exposes an OpenAPI-compatible REST endpoint for basic health and operational checks at http://localhost:8080/health. This is for monitoring the indexer itself; it is not a JSON-RPC endpoint.
 
-:::tip
-⚠️ Security Recommendation
-The GraphQL and REST endpoints are intended for local or private-network access only. Shinzo Hosts are expected to expose necessary public data, so you should NOT directly expose your indexer’s APIs to the public internet. Ensure proper firewall rules or private networking when deploying in production.
+:::tip Security recommendation
+The GraphQL and REST endpoints are intended for local or private-network access only. Shinzo Hosts are the layer expected to expose public data, so you should not expose your indexer's APIs directly to the public internet. Use proper firewall rules or private networking when deploying in production.
 :::
 
-## ShinzoHub Registration
+## ShinzoHub registration
 
-To participate in the Shinzo Network, you must register your indexer. Registration identifies and authenticates your node so it can replicate data and earn rewards. Without this step, your indexer will not be recognized by the network. To register your indexer in ShinzoHub, follow the steps below:
+To participate in the Shinzo Network, you must register your indexer. Registration identifies and authenticates your node so it can replicate data and earn rewards. Without this step, your indexer will not be recognized by the network. To register your indexer in ShinzoHub, follow the steps below.
 
-1. Start your Indexer
-2. Add Shinzo Devnet to Metamask with the following values:
-  - Network name: Shinzo
-  - Default RPC URL: http://rpc.devnet.shinzo.network:8545
-  - Chain ID: 91273002
-  - Currency symbol: SHN
-3. Open the [registration route](http://localhost:8080/registration-app), connect your wallet and share your wallet address in the Shinzo Discord channel to request whitelisting as an Indexer.
-4. Once your address has been whitelisted, return to the registration page, click Register, and select "Indexer" as your role to complete the process.
-5. Submit your registration, then confirm the transaction in MetaMask. You should see a successful registration notification.
+1. Start your indexer.
+1. Add Shinzo Devnet to Metamask with the following values:
+   - Network name: Shinzo.
+   - Default RPC URL: http://rpc.devnet.shinzo.network:8545.
+   - Chain ID: 91273002.
+   - Currency symbol: SHN.
+1. Open the [registration route](http://localhost:8080/registration-app), connect your wallet, and share your wallet address in the Shinzo Discord channel to request whitelisting as an Indexer.
+1. Once your address has been whitelisted, return to the registration page, click Register, and select "Indexer" as your role.
+1. Submit your registration, then confirm the transaction in MetaMask. You should see a successful registration notification.
 
-**🎉 Your indexer is now successfully registered and fully authorized to participate in the Shinzo Network.**
+Your indexer is now registered and authorized to participate in the Shinzo Network.
 
-## Need Help?
+## Need help
 
-If you encounter any issues while installing or running the Shinzo Indexer, please let us know by opening a GitHub issue [here](https://github.com/shinzonetwork/shinzo-indexer-client/issues).
+If you run into issues installing or running the Shinzo Indexer, open a GitHub issue at the [shinzo-indexer-client repository](https://github.com/shinzonetwork/shinzo-indexer-client/issues).


### PR DESCRIPTION
Closes https://github.com/shinzonetwork/docs/issues/114

Also cleans up some markdown formatting, and simplifies language a little bit.