### PR TITLE
Fixes empty search index by setting docsRouteBasePath.

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -261,10 +261,15 @@ const config: Config = {
     [
       require.resolve("@easyops-cn/docusaurus-search-local"),
         {
-          hashed:true,
+          hashed: true,
           language: ["en"],
           highlightSearchTermsOnTargetPage: true,
           explicitSearchResultPath: true,
+          // Docs are served at the site root (see preset docs.routeBasePath: "/").
+          // The search plugin defaults to "docs", which would filter out every page
+          // and produce an empty search index. Mirror the docs route here.
+          docsRouteBasePath: "/",
+          indexBlog: false,
         },
     ],
     [


### PR DESCRIPTION
Closes https://github.com/shinzonetwork/docs/issues/148

I'm a dummy. The search plugin defaults the basepath to `docs`, but our docs are served at `/`. NOW we mirror the docs route in the plugin config. Also turned off blog indexing since we don't have one.