### PR TITLE
Disables copy-button on output codeblocks.

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -344,6 +344,40 @@ pre {
   border: 2px solid var(--code-border);
 }
 
+// Output code blocks (```output)
+// - Darker background to visually distinguish from regular code blocks
+// - No copy button (hidden via CSS)
+// - No gap when immediately following another code block
+.theme-code-block--output {
+  .theme-code-block {
+    --prism-background-color: color-mix(in srgb, var(--code-background) 80%, black);
+    margin-bottom: 0;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+
+    pre {
+      border-top: none;
+      border-top-left-radius: 0;
+      border-top-right-radius: 0;
+    }
+  }
+
+  // Hide copy and word-wrap buttons on output blocks
+  button {
+    display: none !important;
+  }
+}
+
+// Collapse margin/radius between a code block and an immediately following output block
+.theme-code-block:has(+ .theme-code-block--output) {
+  margin-bottom: 0;
+
+  pre {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+}
+
 // Mermaid diagrams: center small ones, allow wide ones to scroll horizontally
 // instead of being squashed (which makes text unreadable).
 .docusaurus-mermaid-container {

--- a/src/theme/CodeBlock/index.tsx
+++ b/src/theme/CodeBlock/index.tsx
@@ -1,0 +1,56 @@
+import React, {isValidElement, type ReactNode} from 'react';
+import useIsBrowser from '@docusaurus/useIsBrowser';
+import ElementContent from '@theme/CodeBlock/Content/Element';
+import StringContent from '@theme/CodeBlock/Content/String';
+import type {Props} from '@theme/CodeBlock';
+
+/**
+ * Best attempt to make the children a plain string so it is copyable. If there
+ * are react elements, we will not be able to copy the content, and it will
+ * return `children` as-is; otherwise, it concatenates the string children
+ * together.
+ */
+function maybeStringifyChildren(children: ReactNode): ReactNode {
+  if (React.Children.toArray(children).some((el) => isValidElement(el))) {
+    return children;
+  }
+  return Array.isArray(children) ? children.join('') : (children as string);
+}
+
+function isOutputLanguage(props: Omit<Props, 'children'>): boolean {
+  if (props.language === 'output') return true;
+  if (
+    typeof props.className === 'string' &&
+    props.className.includes('language-output')
+  )
+    return true;
+  return false;
+}
+
+export default function CodeBlock({
+  children: rawChildren,
+  ...props
+}: Props): ReactNode {
+  const isBrowser = useIsBrowser();
+  const children = maybeStringifyChildren(rawChildren);
+  const CodeBlockComp =
+    typeof children === 'string' ? StringContent : ElementContent;
+
+  const isOutput = isOutputLanguage(props);
+
+  if (isOutput) {
+    return (
+      <div className="theme-code-block--output">
+        <CodeBlockComp key={String(isBrowser)} {...props}>
+          {children as string}
+        </CodeBlockComp>
+      </div>
+    );
+  }
+
+  return (
+    <CodeBlockComp key={String(isBrowser)} {...props}>
+      {children as string}
+    </CodeBlockComp>
+  );
+}


### PR DESCRIPTION
Closes #151.

<img width="972" height="338" alt="Screenshot 2026-05-12 at 13 11 53" src="https://github.com/user-attachments/assets/49996f5f-874e-4ed4-aaa7-33856afec2e2" />
