### PR TITLE
Fixes broken links.

### DIFF
--- a/content/introduction/core-concepts/index.mdx
+++ b/content/introduction/core-concepts/index.mdx
@@ -4,7 +4,7 @@ title: "Core concepts"
 
 # Core concepts
 
-Shinzo runs on four ideas that show up everywhere in the stack: Views, Attestation, DefraDB, and the SHNZ token. The [How it works](./how-it-works.mdx) page covers how they fit together end to end.
+Shinzo runs on four ideas that show up everywhere in the stack: Views, Attestation, DefraDB, and the SHNZ token. The [How it works](../how-it-works) page covers how they fit together end to end.
 
 ## Views
 

--- a/content/reference/components/outpost/index.mdx
+++ b/content/reference/components/outpost/index.mdx
@@ -4,7 +4,7 @@ title: "Outpost"
 
 An outpost is a smart contract deployed on an external chain (not ShinzoHub) that does two things: lets validators prove their identity so they can register as indexers, and lets users pay for view access without interacting with ShinzoHub directly.
 
-Outposts are how external chains connect into the Shinzo network. They handle source chain local logic. [Relayers](relayer.md) bridge the results to [ShinzoHub](shinzohub.md).
+Outposts are how external chains connect into the Shinzo network. They handle source chain local logic. [Relayers](../relayer) bridge the results to [ShinzoHub](../shinzohub).
 
 ## Why outposts exist
 
@@ -21,7 +21,7 @@ The flow:
 1. The indexer generates an operator (delegate) key locally.
 1. The validator's withdrawal key calls the outpost, providing their consensus public key and the operator pubkey, and signs the assertion digest.
 1. Outpost verifies the validator using the chain's native mechanism, stores the signed assertion, and emits an `AssertionSigned` event.
-1. A [relayer](relayer.md) picks up the event and broadcasts `MsgIndexerAssertion` to ShinzoHub.
+1. A [relayer](../relayer) picks up the event and broadcasts `MsgIndexerAssertion` to ShinzoHub.
 1. ShinzoHub verifies the assertion and records a slip for the operator pubkey. The indexer can now register in the Indexer Registry (`0x0212`), signing the registration with its operator key.
 
 ### The digest
@@ -61,7 +61,7 @@ Users on external chains can pay for Shinzo resources without interacting with S
 
 1. User calls `payment()` with a resource type, their DID, a stream ID, and an expiration duration.
 1. The contract stores a `PaymentReceipt` and emits a `PaymentCreated` event.
-1. A [relayer](relayer.md) picks up the event and delivers it to ShinzoHub as `MsgRequestStreamAccess`.
+1. A [relayer](../relayer) picks up the event and delivers it to ShinzoHub as `MsgRequestStreamAccess`.
 
 ## Implementations
 

--- a/content/reference/components/relayer/index.mdx
+++ b/content/reference/components/relayer/index.mdx
@@ -2,7 +2,7 @@
 title: "Relayer"
 ---
 
-A relayer is a process that moves data from an external chain to ShinzoHub. It watches for assertions and payments produced by [outpost](outpost.md) contracts and delivers them to ShinzoHub as Cosmos SDK transactions.
+A relayer is a process that moves data from an external chain to ShinzoHub. It watches for assertions and payments produced by [outpost](../outpost) contracts and delivers them to ShinzoHub as Cosmos SDK transactions.
 
 ShinzoHub does not watch external chains. It only processes messages that are broadcast to it. The relayer reads what happened on the source chain and tells ShinzoHub about it.
 


### PR DESCRIPTION
## Closes https://github.com/shinzonetwork/docs/issues/162

<!-- Issue number is required. PRs without a linked issue will be closed. -->

## Summary

Some links changed because their files got moved from `relayer.mdx` to `./relayer/index.mdx`. The links weren't technically borked, but Docusaurus didn't like them all the same.

## Changes

Updated the link refs.

## Testing

pnpm run build. 

If there's no warning/errors, we're golden.

## Notes for reviewers

N/a
