### PR TITLE
Adds basic backup steps for Defra keys.

### DIFF
--- a/content/indexers/faq.md
+++ b/content/indexers/faq.md
@@ -50,6 +50,13 @@ If you lose your `node-identity-key`, your node’s identity is permanently lost
 
 To avoid this, always back up your node-identity-key.
 
+### How can I backup my keys?
+
+By default your DefraDB keys are stored in `~/.defra/keys`. To back them up, simply copy them from that location to another. For example, if you were backing up your keys to a mounted external drive, you would run:
+
+```shell
+cp -r ~/.defra/keys /mnt/backup-drive/
+```
 
 ### What types of data are indexed?
 


### PR DESCRIPTION
## Closes https://github.com/shinzonetwork/docs/issues/137

## Summary

Adds basic backup steps for Defra keys.

## Changes

- Indexer FAQs page.

## Testing

N/a

## Notes for reviewers

Ordinarily this would go into something like a Keys/Asset Management page. That's in the works, but isn't ready right now. As such, we're publishing this PR right now so users don't get burned in the meantime.
