### PR TITLE
Actually generate sitemap.xml.

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -65,6 +65,12 @@ const config: Config = {
         theme: {
           customCss: "./src/css/custom.scss",
         },
+        sitemap: {
+          lastmod: "date",
+          changefreq: "weekly",
+          priority: 0.5,
+          filename: "sitemap.xml",
+        },
       } satisfies Preset.Options,
     ],
   ],


### PR DESCRIPTION
We had the plugin installed, but didn't have the config set up so the sitemap wasn't getting regenerated. Now we've added it.

## Closes #221 