### PR TITLE
Tutorial: Configuring event filters on shinzo host

### DIFF
--- a/content/guides/configuring-event-filters-on-a-shinzo-host.md
+++ b/content/guides/configuring-event-filters-on-a-shinzo-host.md
@@ -15,13 +15,7 @@ A Shinzo Host subscribes to a stream of blockchain data and writes it to a local
 ```bash
 git clone https://github.com/shinzonetwork/shinzo-host-client.git
 cd shinzo-host-client
-## Setup
-
-First, let's check that the prerequisites are properly installed and get the project set up properly:
-
-1. Check that Docker and Git are installed:
-
-    
+```
 
 ## Configure the host
 
@@ -74,16 +68,17 @@ event_filter:
           topic0: "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
 ```
 
-**How it works:**
+#### How event filtering works
 
 - `mode: "allowlist"`: only events matching a group are stored. Use `"blocklist"` to invert this.
 - `contracts.address`: the on-chain address of the contract you want to watch.
 - `contracts.types: ["log"]`: EVM event logs. This is where token transfers live.
 - `topics.topic0`: the keccak256 hash of the event signature. For `Transfer(address,address,uint256)` this is always `0xddf252ad...`. This is what distinguishes a Transfer log from any other log emitted by the same contract.
 
-**To track a different token**, replace the contract `address` with the one you want. Contract addresses are available on Etherscan.
+#### Tracking different tokens
 
-**To track multiple tokens**, add another group under `groups`:
+- To track another token, replace the contract `address` with the one you want. Contract addresses are available on Etherscan.
+- To track multiple tokens, add another group under `groups`:
 
 ```yaml
   - name: "usdc-transfers"
@@ -99,7 +94,9 @@ event_filter:
 
 The `topic0` for ERC-20 Transfer is the same across all tokens — it's derived from the function signature, not the contract.
 
-**To filter by sender or receiver**, use `topic1` and `topic2`. Indexed event parameters are exposed as topics. For ERC-20 Transfer: `topic1` is the sender, `topic2` is the receiver. Addresses must be zero-padded to 32 bytes:
+#### Filtering by sender and receiver
+
+To filter by sender or receiver, use `topic1` and `topic2`. Indexed event parameters are exposed as topics. For ERC-20 Transfer: `topic1` is the sender, `topic2` is the receiver. Addresses must be zero-padded to 32 bytes:
 
 ```yaml
 topics:

--- a/content/guides/configuring-event-filters-on-a-shinzo-host.md
+++ b/content/guides/configuring-event-filters-on-a-shinzo-host.md
@@ -1,0 +1,223 @@
+---
+title: Configuring Event Filters on a Shinzo Host
+sidebar_label: Configuring Event Filters on a Shinzo Host
+sidebar_position: 1
+description: Configuring Event Filters on a Shinzo Host
+---
+
+## Overview
+
+A Shinzo Host subscribes to a stream of blockchain data and writes it to a local DefraDB instance. By default it stores everything. This guide configures it to store only specific contract events using USDT ERC-20 transfers as the example and prune old data automatically.
+
+## Prerequisites
+
+- Docker Desktop installed and running
+- Git
+- Basic familiarity with YAML
+
+## 1. Clone the repository
+
+```bash
+git clone https://github.com/shinzonetwork/shinzo-host-client.git
+cd shinzo-host-client
+```
+
+## 2. Configure the host
+
+Open `config/config.yaml`. The sections below are the ones you need to understand.
+
+### Database key
+
+```yaml
+defradb:
+  keyring_secret: "your-secret-here"
+```
+
+This key encrypts the local DefraDB store. Set it to something secret before running in production.
+
+### Chain connection
+
+```yaml
+shinzo:
+  hub_base_url: rpc.develop.devnet.shinzo.network:26657
+  start_height: 0
+```
+
+`start_height: 0` means start from the current chain head. Set it to a specific block number to begin indexing from a point in the past.
+
+### Pruning
+
+```yaml
+pruner:
+  enabled: true
+  max_blocks: 2000
+  interval_seconds: 30
+```
+
+The pruner deletes data for blocks older than `max_blocks`. At roughly 12 seconds per Ethereum block, 2000 blocks is about 6–7 hours of history. Increase this if you need more, keeping in mind the storage implications.
+
+### Event filter
+
+This is what controls what gets stored. Without a filter, everything is written to disk.
+
+```yaml
+event_filter:
+  enabled: true
+  mode: "allowlist"
+
+  groups:
+    - name: "usdt-transfers"
+      enabled: true
+
+      contracts:
+        - name: "USDT"
+          address: "0xdAC17F958D2ee523a2206206994597C13D831ec7"
+          types: ["log"]
+
+      topics:
+        - name: "Transfer"
+          topic0: "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+```
+
+**How it works:**
+
+- `mode: "allowlist"` — only events matching a group are stored. Use `"blocklist"` to invert this.
+- `contracts.address` — the on-chain address of the contract you want to watch.
+- `contracts.types: ["log"]` — EVM event logs. This is where token transfers live.
+- `topics.topic0` — the keccak256 hash of the event signature. For `Transfer(address,address,uint256)` this is always `0xddf252ad...`. This is what distinguishes a Transfer log from any other log emitted by the same contract.
+
+**To track a different token**, replace the contract `address` with the one you want. Contract addresses are available on Etherscan.
+
+**To track multiple tokens**, add another group under `groups`:
+
+```yaml
+  - name: "usdc-transfers"
+    enabled: true
+    contracts:
+      - name: "USDC"
+        address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+        types: ["log"]
+    topics:
+      - name: "Transfer"
+        topic0: "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+```
+
+The `topic0` for ERC-20 Transfer is the same across all tokens — it's derived from the function signature, not the contract.
+
+**To filter by sender or receiver**, use `topic1` and `topic2`. Indexed event parameters are exposed as topics. For ERC-20 Transfer: `topic1` is the sender, `topic2` is the receiver. Addresses must be zero-padded to 32 bytes:
+
+```yaml
+topics:
+  - name: "Transfer"
+    topic0: "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+    topic1: "0x000000000000000000000000<sender-address-without-0x>"
+```
+
+**To compute `topic0` for a custom event**, hash its canonical signature:
+
+```javascript
+// ethers.js
+const { ethers } = require("ethers");
+console.log(ethers.utils.id("Transfer(address,address,uint256)"));
+```
+
+Or use an online keccak256 tool at `https://emn178.github.io/online-tools/keccak_256.html`.
+
+### P2P peers
+
+```yaml
+p2p:
+  enabled: true
+  bootstrap_peers:
+    - '/ip4/34.63.13.57/tcp/9171/p2p/12D3KooWBT2F45LH7Gy6EadTE3sm7PKofyJ3RXcCnKufdu4L5c4M'
+    - '/ip4/35.208.241.78/tcp/9171/p2p/12D3KooWDYXkjdncFL3X1SaaYBpFi4XfWskbXv4y5gYdTvmGm3bo'
+    - '/ip4/35.209.45.53/tcp/9171/p2p/12D3KooWNLCXZEVZoM6NwU1i7zAZDscEZHhynsF74M5hP99sptM9'
+```
+
+These are the addresses of the peers your host connects to for data. Check the [Shinzo Validators list](https://registration.shinzo.network/validators) for updated peer lists; these change when the network is updated.
+
+## 3. Mount your config in Docker
+
+In `docker-compose.yml`, uncomment the volumes entry so Docker uses your config file:
+
+```yaml
+volumes:
+  - ./config/config.yaml:/app/config.yaml:ro
+```
+
+## 4. Start the host
+
+```bash
+docker compose up -d
+```
+
+Verify it's running:
+
+```bash
+docker ps
+```
+
+Both `shinzo-host` and `shinzo-host-client-nginx-1` should show status `Up` and `(healthy)`.
+
+
+## 5. Verify data is being collected
+
+### Health
+
+```bash
+curl http://localhost:8080/health
+```
+
+Expected response:
+
+```json
+{ "status": "healthy", "defradb_connected": true }
+```
+
+### Processing metrics
+
+```bash
+curl -s http://localhost:8080/metrics | jq
+```
+
+Key fields:
+
+| Field | Meaning |
+|---|---|
+| `blocks_processed` | Blocks scanned so far |
+| `logs_processed` | Events captured matching your filter |
+| `attestations_created` | Data integrity records written |
+
+If `logs_processed` stays at 0 but `blocks_processed` is climbing, either no matching events have occurred in the blocks being indexed, or the connected indexer is not providing full transaction data (only block headers). If `transactions_processed` is also 0, contact the Shinzo team for access to a full-data indexer.
+
+### Query stored logs
+
+```bash
+curl -s -X POST http://localhost:9181/api/v0/graphql \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{ Ethereum__Mainnet__Log(limit: 10) { _docID address topics blockNumber } }"}' \
+  | jq
+```
+
+To filter down to a specific contract:
+
+```bash
+curl -s -X POST http://localhost:9181/api/v0/graphql \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{ Ethereum__Mainnet__Log(filter: {address: {_eq: \"0xdAC17F958D2ee523a2206206994597C13D831ec7\"}}, limit: 10) { _docID address topics blockNumber data } }"}' \
+  | jq
+```
+
+The `topics` array maps directly to `topic0`–`topic3`. For a Transfer event: `topics[0]` is the event signature, `topics[1]` is the sender, `topics[2]` is the receiver. The transfer amount is ABI-encoded in the `data` field and must be decoded in your application.
+
+
+## Troubleshooting
+
+**Container restarts immediately**
+Run `docker logs shinzo-host | tail -50`. A YAML parse error (indentation, missing quotes) or unset `keyring_secret` are the most common causes. Validate your config at `https://www.yamllint.com/`.
+
+**Cannot connect to health endpoint**
+Check the container is actually running (`docker ps`), then check if port 8080 is already in use on your machine.
+
+**P2P connection warnings (`peer id mismatch`)**
+Your `bootstrap_peers` list is stale. Replace it with current peers from the Shinzo docs.

--- a/content/guides/configuring-event-filters-on-a-shinzo-host.md
+++ b/content/guides/configuring-event-filters-on-a-shinzo-host.md
@@ -15,27 +15,27 @@ A Shinzo Host subscribes to a stream of blockchain data and writes it to a local
 - Git
 - Basic familiarity with YAML
 
-## 1. Clone the repository
+## Clone the repository
 
 ```bash
 git clone https://github.com/shinzonetwork/shinzo-host-client.git
 cd shinzo-host-client
 ```
 
-## 2. Configure the host
+## Configure the host
 
 Open `config/config.yaml`. The sections below are the ones you need to understand.
 
-### Database key
+### Securing Your Local Database
 
 ```yaml
 defradb:
   keyring_secret: "your-secret-here"
 ```
 
-This key encrypts the local DefraDB store. Set it to something secret before running in production.
+This key encrypts the local DefraDB instance. Use a strong secret value before running a host in production.
 
-### Chain connection
+### Connecting to the Shinzo Network
 
 ```yaml
 shinzo:
@@ -43,7 +43,7 @@ shinzo:
   start_height: 0
 ```
 
-`start_height: 0` means start from the current chain head. Set it to a specific block number to begin indexing from a point in the past.
+Views can be published to and discovered through ShinzoHub. Once you’ve created a view, connect it to ShinzoHub to make it available across the network and enable other builders to access and use it. See the documentation for more details [here](https://docs.shinzo.network/reference/components/shinzohub/)
 
 ### Pruning
 
@@ -56,7 +56,7 @@ pruner:
 
 The pruner deletes data for blocks older than `max_blocks`. At roughly 12 seconds per Ethereum block, 2000 blocks is about 6–7 hours of history. Increase this if you need more, keeping in mind the storage implications.
 
-### Event filter
+### Filtering Blockchain Events
 
 This is what controls what gets stored. Without a filter, everything is written to disk.
 
@@ -136,7 +136,9 @@ p2p:
 
 These are the addresses of the peers your host connects to for data. Check the [Shinzo Validators list](https://registration.shinzo.network/validators) for updated peer lists; these change when the network is updated.
 
-## 3. Mount your config in Docker
+## Running the Host
+
+### Mount your Configuration
 
 In `docker-compose.yml`, uncomment the volumes entry so Docker uses your config file:
 
@@ -145,13 +147,13 @@ volumes:
   - ./config/config.yaml:/app/config.yaml:ro
 ```
 
-## 4. Start the host
+### Start the Host
 
 ```bash
 docker compose up -d
 ```
 
-Verify it's running:
+### Confirm Containers Are Healthy
 
 ```bash
 docker ps
@@ -160,7 +162,7 @@ docker ps
 Both `shinzo-host` and `shinzo-host-client-nginx-1` should show status `Up` and `(healthy)`.
 
 
-## 5. Verify data is being collected
+## Verifying Data Ingestion
 
 ### Health
 
@@ -214,10 +216,13 @@ The `topics` array maps directly to `topic0`–`topic3`. For a Transfer event: `
 ## Troubleshooting
 
 **Container restarts immediately**
-Run `docker logs shinzo-host | tail -50`. A YAML parse error (indentation, missing quotes) or unset `keyring_secret` are the most common causes. Validate your config at `https://www.yamllint.com/`.
+
+Run `docker logs shinzo-host | tail -50`. A YAML parse error (indentation, missing quotes) or unset `keyring_secret` are the most common causes. Validate your config at https://www.yamllint.com/.
 
 **Cannot connect to health endpoint**
-Check the container is actually running (`docker ps`), then check if port 8080 is already in use on your machine.
 
-**P2P connection warnings (`peer id mismatch`)**
+* Verify the container is running with `docker ps`. If the container is healthy but the endpoint is still unreachable, check whether another application is already using port 8080.
+
+**P2P connection warnings (peer id mismatch)**
+
 Your `bootstrap_peers` list is stale. Replace it with current peers from the Shinzo docs.

--- a/content/guides/configuring-event-filters-on-a-shinzo-host.md
+++ b/content/guides/configuring-event-filters-on-a-shinzo-host.md
@@ -1,19 +1,14 @@
 ---
 title: Configuring Event Filters on a Shinzo Host
-sidebar_label: Configuring Event Filters on a Shinzo Host
-sidebar_position: 1
-description: Configuring Event Filters on a Shinzo Host
+description: "Shinzo hosts will store absolutely everything it is given from an Indexer by default. In this guide you will learn how to configure a Host to only store USDT ERC-20 contact events."
 ---
 
-## Overview
-
-A Shinzo Host subscribes to a stream of blockchain data and writes it to a local DefraDB instance. By default it stores everything. This guide configures it to store only specific contract events using USDT ERC-20 transfers as the example and prune old data automatically.
+A Shinzo Host subscribes to a stream of blockchain data and writes it to a local DefraDB instance. By default the Host stores everything, but they can be configured to only store specific data. As an example, this guide configures the Host client to only store USDT ERC-20 transfer events.
 
 ## Prerequisites
 
 - Docker Desktop installed and running
 - Git
-- Basic familiarity with YAML
 
 ## Clone the repository
 
@@ -132,6 +127,10 @@ These are the addresses of the peers your host connects to for data. Check the [
 
 ## Running the Host
 
+1. In `docker-compose.yml`, uncomment the volumes entry so Docker uses your config file:
+
+    
+
 ### Mount your Configuration
 
 In `docker-compose.yml`, uncomment the volumes entry so Docker uses your config file:
@@ -160,15 +159,6 @@ Both `shinzo-host` and `shinzo-host-client-nginx-1` should show status `Up` and 
 
 ### Health
 
-```bash
-curl http://localhost:8080/health
-```
-
-Expected response:
-
-```json
-{ "status": "healthy", "defradb_connected": true }
-```
 
 ### Processing metrics
 
@@ -184,7 +174,7 @@ Key fields:
 | `logs_processed` | Events captured matching your filter |
 | `attestations_created` | Data integrity records written |
 
-If `logs_processed` stays at 0 but `blocks_processed` is climbing, either no matching events have occurred in the blocks being indexed, or the connected indexer is not providing full transaction data (only block headers). If `transactions_processed` is also 0, contact the Shinzo team for access to a full-data indexer.
+If `logs_processed` stays at 0 but `blocks_processed` is climbing, either no matching events have occurred in the blocks being indexed, or the connected indexer is not providing full transaction data (only block headers). If `transactions_processed` is also 0, contact the [Shinzo team](https://discord.shinzo.network/) for access to a full-data indexer.
 
 ### Query stored logs
 

--- a/content/guides/configuring-event-filters-on-a-shinzo-host.md
+++ b/content/guides/configuring-event-filters-on-a-shinzo-host.md
@@ -37,12 +37,6 @@ This key encrypts the local DefraDB instance. Use a strong secret value before r
 
 ### Connecting to the Shinzo Network
 
-```yaml
-shinzo:
-  hub_base_url: rpc.develop.devnet.shinzo.network:26657
-  start_height: 0
-```
-
 Views can be published to and discovered through ShinzoHub. Once you’ve created a view, connect it to ShinzoHub to make it available across the network and enable other builders to access and use it. See the documentation for more details [here](https://docs.shinzo.network/reference/components/shinzohub/)
 
 ### Pruning

--- a/content/guides/configuring-event-filters-on-a-shinzo-host.md
+++ b/content/guides/configuring-event-filters-on-a-shinzo-host.md
@@ -130,10 +130,6 @@ These are the addresses of the peers your host connects to for data. Check the [
 
 ## Running the Host
 
-1. In `docker-compose.yml`, uncomment the volumes entry so Docker uses your config file:
-
-    
-
 ### Mount your Configuration
 
 In `docker-compose.yml`, uncomment the volumes entry so Docker uses your config file:
@@ -143,9 +139,6 @@ volumes:
   - ./config/config.yaml:/app/config.yaml:ro
 ```
 
-### Start the Host
-
-
 ### Confirm Containers Are Healthy
 
 ```bash
@@ -154,11 +147,19 @@ docker ps
 
 Both `shinzo-host` and `shinzo-host-client-nginx-1` should show status `Up` and `(healthy)`.
 
-
 ## Verifying Data Ingestion
 
 ### Health
 
+```bash
+curl http://localhost:8080/health
+```
+
+Expected response:
+
+```json
+{ "status": "healthy", "defradb_connected": true }
+```
 
 ### Processing metrics
 

--- a/content/guides/configuring-event-filters-on-a-shinzo-host.md
+++ b/content/guides/configuring-event-filters-on-a-shinzo-host.md
@@ -15,7 +15,13 @@ A Shinzo Host subscribes to a stream of blockchain data and writes it to a local
 ```bash
 git clone https://github.com/shinzonetwork/shinzo-host-client.git
 cd shinzo-host-client
-```
+## Setup
+
+First, let's check that the prerequisites are properly installed and get the project set up properly:
+
+1. Check that Docker and Git are installed:
+
+    
 
 ## Configure the host
 
@@ -32,7 +38,7 @@ This key encrypts the local DefraDB instance. Use a strong secret value before r
 
 ### Connecting to the Shinzo Network
 
-Views can be published to and discovered through ShinzoHub. Once you’ve created a view, connect it to ShinzoHub to make it available across the network and enable other builders to access and use it. See the documentation for more details [here](https://docs.shinzo.network/reference/components/shinzohub/)
+Views can be published to and discovered through ShinzoHub. Once you’ve created a view, connect it to ShinzoHub to make it available across the network and enable other builders to access and use it. [See the documentation for more details.](/reference/components/shinzohub/).
 
 ### Pruning
 
@@ -70,10 +76,10 @@ event_filter:
 
 **How it works:**
 
-- `mode: "allowlist"` — only events matching a group are stored. Use `"blocklist"` to invert this.
-- `contracts.address` — the on-chain address of the contract you want to watch.
-- `contracts.types: ["log"]` — EVM event logs. This is where token transfers live.
-- `topics.topic0` — the keccak256 hash of the event signature. For `Transfer(address,address,uint256)` this is always `0xddf252ad...`. This is what distinguishes a Transfer log from any other log emitted by the same contract.
+- `mode: "allowlist"`: only events matching a group are stored. Use `"blocklist"` to invert this.
+- `contracts.address`: the on-chain address of the contract you want to watch.
+- `contracts.types: ["log"]`: EVM event logs. This is where token transfers live.
+- `topics.topic0`: the keccak256 hash of the event signature. For `Transfer(address,address,uint256)` this is always `0xddf252ad...`. This is what distinguishes a Transfer log from any other log emitted by the same contract.
 
 **To track a different token**, replace the contract `address` with the one you want. Contract addresses are available on Etherscan.
 
@@ -110,7 +116,7 @@ const { ethers } = require("ethers");
 console.log(ethers.utils.id("Transfer(address,address,uint256)"));
 ```
 
-Or use an online keccak256 tool at `https://emn178.github.io/online-tools/keccak_256.html`.
+Or use an [online keccak256 tool](https://emn178.github.io/online-tools/keccak_256.html).
 
 ### P2P peers
 
@@ -142,9 +148,6 @@ volumes:
 
 ### Start the Host
 
-```bash
-docker compose up -d
-```
 
 ### Confirm Containers Are Healthy
 
@@ -201,11 +204,11 @@ The `topics` array maps directly to `topic0`–`topic3`. For a Transfer event: `
 
 **Container restarts immediately**
 
-Run `docker logs shinzo-host | tail -50`. A YAML parse error (indentation, missing quotes) or unset `keyring_secret` are the most common causes. Validate your config at https://www.yamllint.com/.
+Run `docker logs shinzo-host | tail -50`. A YAML parse error (indentation, missing quotes) or unset `keyring_secret` are the most common causes. Use a [YAML validator](https://www.yamllint.com/) to make sure your config is correct.
 
 **Cannot connect to health endpoint**
 
-* Verify the container is running with `docker ps`. If the container is healthy but the endpoint is still unreachable, check whether another application is already using port 8080.
+Verify the container is running with `docker ps`. If the container is healthy but the endpoint is still unreachable, check whether another application is already using port 8080.
 
 **P2P connection warnings (peer id mismatch)**
 

--- a/content/guides/configuring-event-filters-on-a-shinzo-host.md
+++ b/content/guides/configuring-event-filters-on-a-shinzo-host.md
@@ -7,7 +7,7 @@ A Shinzo Host subscribes to a stream of blockchain data and writes it to a local
 
 ## Prerequisites
 
-- Docker Desktop installed and running
+- Docker installed and running
 - Git
 
 ## Clone the repository

--- a/content/guides/configuring-event-filters-on-a-shinzo-host/index.mdx
+++ b/content/guides/configuring-event-filters-on-a-shinzo-host/index.mdx
@@ -12,7 +12,7 @@ A Shinzo Host subscribes to a stream of blockchain data and writes it to a local
 
 ## Clone the repository
 
-```bash
+```shell
 git clone https://github.com/shinzonetwork/shinzo-host-client.git
 cd shinzo-host-client
 ```
@@ -21,7 +21,7 @@ cd shinzo-host-client
 
 Open `config/config.yaml`. The sections below are the ones you need to understand.
 
-### Securing Your Local Database
+### Securing your local database
 
 ```yaml
 defradb:
@@ -30,9 +30,9 @@ defradb:
 
 This key encrypts the local DefraDB instance. Use a strong secret value before running a host in production.
 
-### Connecting to the Shinzo Network
+### Connecting to the Shinzo network
 
-Views can be published to and discovered through ShinzoHub. Once you’ve created a view, connect it to ShinzoHub to make it available across the network and enable other builders to access and use it. [See the documentation for more details.](/reference/components/shinzohub/).
+Views can be published to and discovered through ShinzoHub. Once you've created a view, connect it to ShinzoHub to make it available across the network and enable other builders to access and use it. [See the documentation for more details.](/reference/components/shinzohub/).
 
 ### Pruning
 
@@ -43,9 +43,9 @@ pruner:
   interval_seconds: 30
 ```
 
-The pruner deletes data for blocks older than `max_blocks`. At roughly 12 seconds per Ethereum block, 2000 blocks is about 6–7 hours of history. Increase this if you need more, keeping in mind the storage implications.
+The pruner deletes data for blocks older than `max_blocks`. At roughly 12 seconds per Ethereum block, 2000 blocks is about 6-7 hours of history. Increase this if you need more, keeping in mind the storage implications.
 
-### Filtering Blockchain Events
+### Filtering blockchain events
 
 This is what controls what gets stored. Without a filter, everything is written to disk.
 
@@ -105,7 +105,9 @@ topics:
     topic1: "0x000000000000000000000000<sender-address-without-0x>"
 ```
 
-**To compute `topic0` for a custom event**, hash its canonical signature:
+#### Computing `topic0` for a custom event
+
+Hash its canonical signature:
 
 ```javascript
 // ethers.js
@@ -128,9 +130,9 @@ p2p:
 
 These are the addresses of the peers your host connects to for data. Check the [Shinzo Validators list](https://registration.shinzo.network/validators) for updated peer lists; these change when the network is updated.
 
-## Running the Host
+## Running the host
 
-### Mount your Configuration
+### Mount your configuration
 
 In `docker-compose.yml`, uncomment the volumes entry so Docker uses your config file:
 
@@ -139,19 +141,19 @@ volumes:
   - ./config/config.yaml:/app/config.yaml:ro
 ```
 
-### Confirm Containers Are Healthy
+### Confirm containers are healthy
 
-```bash
+```shell
 docker ps
 ```
 
 Both `shinzo-host` and `shinzo-host-client-nginx-1` should show status `Up` and `(healthy)`.
 
-## Verifying Data Ingestion
+## Verifying data ingestion
 
 ### Health
 
-```bash
+```shell
 curl http://localhost:8080/health
 ```
 
@@ -163,14 +165,14 @@ Expected response:
 
 ### Processing metrics
 
-```bash
+```shell
 curl -s http://localhost:8080/metrics | jq
 ```
 
 Key fields:
 
 | Field | Meaning |
-|---|---|
+| --- | --- |
 | `blocks_processed` | Blocks scanned so far |
 | `logs_processed` | Events captured matching your filter |
 | `attestations_created` | Data integrity records written |
@@ -179,7 +181,7 @@ If `logs_processed` stays at 0 but `blocks_processed` is climbing, either no mat
 
 ### Query stored logs
 
-```bash
+```shell
 curl -s -X POST http://localhost:9181/api/v0/graphql \
   -H "Content-Type: application/json" \
   -d '{"query": "{ Ethereum__Mainnet__Log(limit: 10) { _docID address topics blockNumber } }"}' \
@@ -188,26 +190,26 @@ curl -s -X POST http://localhost:9181/api/v0/graphql \
 
 To filter down to a specific contract:
 
-```bash
+```shell
 curl -s -X POST http://localhost:9181/api/v0/graphql \
   -H "Content-Type: application/json" \
   -d '{"query": "{ Ethereum__Mainnet__Log(filter: {address: {_eq: \"0xdAC17F958D2ee523a2206206994597C13D831ec7\"}}, limit: 10) { _docID address topics blockNumber data } }"}' \
   | jq
 ```
 
-The `topics` array maps directly to `topic0`–`topic3`. For a Transfer event: `topics[0]` is the event signature, `topics[1]` is the sender, `topics[2]` is the receiver. The transfer amount is ABI-encoded in the `data` field and must be decoded in your application.
+The `topics` array maps directly to `topic0`-`topic3`. For a Transfer event: `topics[0]` is the event signature, `topics[1]` is the sender, `topics[2]` is the receiver. The transfer amount is ABI-encoded in the `data` field and must be decoded in your application.
 
 
 ## Troubleshooting
 
-**Container restarts immediately**
+#### Container restarts immediately
 
 Run `docker logs shinzo-host | tail -50`. A YAML parse error (indentation, missing quotes) or unset `keyring_secret` are the most common causes. Use a [YAML validator](https://www.yamllint.com/) to make sure your config is correct.
 
-**Cannot connect to health endpoint**
+#### Cannot connect to health endpoint
 
 Verify the container is running with `docker ps`. If the container is healthy but the endpoint is still unreachable, check whether another application is already using port 8080.
 
-**P2P connection warnings (peer id mismatch)**
+#### P2P connection warnings (peer id mismatch)
 
 Your `bootstrap_peers` list is stale. Replace it with current peers from the Shinzo docs.

--- a/content/guides/configuring-event-filters-on-a-shinzo-host/index.mdx
+++ b/content/guides/configuring-event-filters-on-a-shinzo-host/index.mdx
@@ -3,12 +3,12 @@ title: Configuring Event Filters on a Shinzo Host
 description: "Shinzo hosts will store absolutely everything it is given from an Indexer by default. In this guide you will learn how to configure a Host to only store USDT ERC-20 contact events."
 ---
 
-A Shinzo Host subscribes to a stream of blockchain data and writes it to a local DefraDB instance. By default the Host stores everything, but they can be configured to only store specific data. As an example, this guide configures the Host client to only store USDT ERC-20 transfer events.
+A Shinzo Host subscribes to a stream of blockchain data and writes it to a local DefraDB instance. By default the Host stores everything, but it can be configured to only store specific data. This guide configures the Host client to only store USDT ERC-20 transfer events.
 
 ## Prerequisites
 
-- Docker installed and running
-- Git
+- Docker installed and running.
+- Git.
 
 ## Clone the repository
 
@@ -32,7 +32,7 @@ This key encrypts the local DefraDB instance. Use a strong secret value before r
 
 ### Connecting to the Shinzo network
 
-Views can be published to and discovered through ShinzoHub. Once you've created a view, connect it to ShinzoHub to make it available across the network and enable other builders to access and use it. [See the documentation for more details.](/reference/components/shinzohub/).
+Views can be published to and discovered through ShinzoHub. Once you've created a view, connect it to ShinzoHub to make it available across the network for other builders to use. [See the documentation for more details.](/reference/components/shinzohub/).
 
 ### Pruning
 
@@ -78,7 +78,7 @@ event_filter:
 #### Tracking different tokens
 
 - To track another token, replace the contract `address` with the one you want. Contract addresses are available on Etherscan.
-- To track multiple tokens, add another group under `groups`:
+- To track multiple tokens, add another group under `groups`.
 
 ```yaml
   - name: "usdc-transfers"
@@ -92,7 +92,7 @@ event_filter:
         topic0: "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
 ```
 
-The `topic0` for ERC-20 Transfer is the same across all tokens — it's derived from the function signature, not the contract.
+The `topic0` for ERC-20 Transfer is the same across all tokens, derived from the function signature rather than the contract.
 
 #### Filtering by sender and receiver
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -180,6 +180,11 @@ const config: Config = {
           label: "Guides",
         },
         {
+          to: "/guides/configuring-event-filters-on-a-shinzo-host",
+          position: "left",
+          label: "Guides",
+        },
+        {
           to: "/reference/architecture-overview",
           position: "left",
           label: "Reference",

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -52,7 +52,8 @@ const sidebars: SidebarsConfig = {
       type: "category",
       label: "Guides",
       items: [
-        "guides/building-apps-with-shinzo"
+        "guides/building-apps-with-shinzo",
+        "guides/configuring-event-filters-on-a-shinzo-host"
       ],
     },
     {

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -53,7 +53,7 @@ const sidebars: SidebarsConfig = {
       label: "Guides",
       items: [
         "guides/building-apps-with-shinzo",
-        "guides/configuring-event-filters-on-a-shinzo-host"
+        "guides/configuring-event-filters-on-a-shinzo-host/index"
       ],
     },
     {


### PR DESCRIPTION
## Closes #

#192 

## Summary

Tutorial on configuring Shinzo Host, as a host it subscribes to a stream of blockchain data and writes it to a local DefraDB instance. By default it stores everything. In this guide, it configures to store only specific contract events using USDT ERC-20 transfers as the example and prune old data automatically.