### PR TITLE
Update Generator docs for joining Shinzo tesnet

### DIFF
--- a/content/indexers/install/index.md
+++ b/content/indexers/install/index.md
@@ -3,7 +3,7 @@ title = "Install"
 weight = 2
 +++
 
-This page covers installing a Shinzo Indexer with Docker or from source. To complete an indexer setup, you must also register it with the Shinzo Network (see [Registration](./register)).
+This page covers installing a Shinzo Indexer with Docker or from source. To complete an indexer setup, you must also register it with the Shinzo Network (see [Registration](/indexers/register)).
 
 ## Hardware recommendations
 

--- a/content/indexers/register/index.md
+++ b/content/indexers/register/index.md
@@ -3,45 +3,66 @@ title = "Register"
 weight = 3
 +++
 
-To participate in the Shinzo Network, you must register your Indexer. Registration identifies and authenticates your node so it can replicate data and earn rewards. Without this step, your Indexer will not be recognized by the network. To register in ShinzoHub, follow the steps below.
+To participate in the Shinzo Network, you must register your node in the **Technical Registry**. Registration identifies and authenticates your node so it can replicate data and earn rewards. Without this step, your node will not be recognized by the network. To register, follow the steps below.
 
 {% admonition(type="info") %}
-If you are a validator on a source chain, registration may also prompt you to submit an [assertion](/reference/components/outpost#validator-assertions). Assertions require your **consensus public key** for the chain you validate on. See [Consensus public key](/reference/components/outpost#consensus-public-key) for what that is and how to retrieve it.
+If you are registering as a **Generator**, registration requires an [assertion](/reference/components/outpost#validator-assertions) step to verify your generator's identity before it is registered on-chain. Assertions require your **consensus public key** for the source chain your generator monitors. See [Consensus public key](/reference/components/outpost#consensus-public-key) for what that is and how to retrieve it.
 {% end %}
 
-
-1. Start your Indexer.
-1. Add the Shinzo Devnet to your browser wallet with the following values:
+1. Start your Generator Client.
+1. Add the Shinzo Testnet to your browser wallet with the following values:
    - Network name: `Shinzo`
    - Default RPC URL: `http://rpc.devnet.shinzo.network:8545`
    - Chain ID: `91273002`
    - Currency symbol: `SHNZ`
-1. Go to [localhost:8080](http://localhost:8080/registration-app) and select **Connect** to connect your wallet.
+1. Go to the [Technical Registry](http://localhost:8080/registration-app) and connect your wallet using the button in the top-right corner.
 
     {% admonition(type="info") %}
-    If your Indexer is running on a remote server (like Hetzner, DigialOcean, GCP, AWS, etc), you can use SSH local port forwarding to access the registration page.
+    If your node is running on a remote server (like Hetzner, DigitalOcean, GCP, AWS, etc), you can use SSH local port forwarding to access the registration page.
 
 1. On your local machine, run `ssh -L 8080:localhost:8080 user@your-hetzner-ip`.
 1. Open `http://localhost:8080/registration-app` in your browser.
     {% end %}
 
-1. Share your wallet address in the [Shinzo Discord](https://discord.com/channels/1444411399882408011/1444411402239344802) channel to request allowlisting as an Indexer.
+1. From the Technical Registry homepage, click **Register as Generator** to start the two-step registration flow.
 
-    It may take ~24 hours for your address to be added to the allowlist. Once your address has been added:
+### Step 1: Assertion
 
-1. Return to the [registration page](http://localhost:8080/registration-app), click **Register**, and select **Indexer** as your role.
-1. Submit your registration and then confirm the transaction in your browser wallet. You should see a successful registration notification.
+The Assertion step verifies ownership of your generator identity.
+Provide:
 
-Your Indexer is now registered and authorized to participate in the Shinzo Network.
+- **Consensus Public Key**: The consensus public key of your generator node.
+- **Source Chain**: The blockchain your generator node monitors (e.g. Ethereum).
+
+Click **Sign & Submit** to sign a message with your wallet, proving ownership of the generator's identity.
+
+### Step 2: Registration (register on-chain)
+
+The Registration step records your generator on-chain.
+Provide:
+
+- **Signed message**: The signed payload generated during the Assertion step.
+- **Public key**: The public key that identifies your generator node.
+- **Signed public key message**: A signature proving ownership of the public key.
+- **Connection string**: The endpoint operators and hosts will use to connect to your generator node.
+- **Source chain**: Confirm the chain your generator node is monitoring.
+
+After completing all required fields, click Register and confirm the transaction in your wallet. Once the transaction is confirmed, your generator is successfully registered on-chain.
+
+## Confirm your registration
+
+Return to the Technical Registry homepage. Your generator should now appear in the **Registered Generators** table, along with its Address, DID, Chain, Connection String and Status.
+
+Your Generator is now registered and authorized to participate in the Shinzo Network.
 
 ## Backup your node identity key
 
-This key defines your Indexer’s identity on the network. Persisting it ensures your node can be restored without losing identity.
+This key defines your node's identity on the network. Persisting it ensures your node can be restored without losing identity.
 
 - Store a secure backup of the key.
 - In a recovery scenario, place it back into the same path (e.g. `/defra/keys`).
 - Use the same keyring/secret configuration.
 
 {% admonition(type="warning") %}
-If this key is lost, and there is no backup available, you will be unable to restore your Indexer with the same identity.
+If this key is lost, and there is no backup available, you will be unable to restore your node with the same identity.
 {% end %}


### PR DESCRIPTION
## Closes #

fixes #262 and #261 

## Summary

- Update the Generator Registration page to reflect the new onboarding flow for joining the Shinzo Network during the public testnet.
- Fixes broken link to registration page