### PR TITLE
Standardize the testnet RPC endpoints and remove devnet instances

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -86,12 +86,18 @@ If you're a developer working on a dapp, wallet, or any kind of web3 app, Views 
 
 You build Views with `viewkit`, Shinzo's CLI, and deploy them to the network. Any Host client can then pick up the View, run it, and serve the results. Your application subscribes through the [app-sdk](https://github.com/shinzonetwork/app-sdk) and queries the resulting data locally.
 
+
 ## Where the project is today
 
-Shinzo is in active development on devnet. These core pieces work end to end:
+Shinzo's public testnet is now live. Anyone can join the network by running a Generator or Host and participate in validating the protocol before mainnet.
 
-- The Generator client ingests Ethereum Mainnet from a Geth node, signs documents, and replicates them over DefraDB's libp2p layer.
-- The Host client receives that data, builds attestation records, applies Lens transforms, and serves Views to subscribers.
-- Viewkit is usable for defining, packaging, and deploying Views to devnet today.
-- ShinzoHub (built on the Cosmos SDK) handles View registration and access control, and talks to Sourcehub over IBC to gate subscriptions behind payment.
-- The app-sdk lets Go applications embed DefraDB and run attestation-filtered queries against it.
+The current testnet includes:
+
+- The **Generator** client indexes Ethereum Mainnet from a Geth node, signs indexed data and replicates it across the network using DefraDB's libp2p-based replication layer.
+- The **Host** client receives replicated data from Generators, materializes registered Views using Lens transforms, and serves GraphQL queries to applications.
+- **Viewkit** allows developers to define, package and deploy custom Views to the network, making indexed datasets immediately available to participating Hosts.
+- **ShinzoHub** coordinates network participation, View registration, entity registration, and access control for the testnet.
+- The **Gateway** provides a unified GraphQL endpoint by routing requests across Hosts and validating responses through network consensus.
+- The **App SDK** enables Go applications to embed Shinzo components and query attestation-filtered data directly from the network.
+
+This testnet is intended to validate Shinzo's trustless indexing architecture under real-world conditions, gather feedback from operators and developers and harden the protocol ahead of mainnet.

--- a/content/changelog/_index.md
+++ b/content/changelog/_index.md
@@ -1,0 +1,6 @@
++++
+sort_by = "weight"
+render = false
+page_template = "page.html"
+weight = 8
++++

--- a/content/generator/install/index.md
+++ b/content/generator/install/index.md
@@ -61,7 +61,7 @@ These steps use Docker to run the Shinzo Generator client. To build the Generato
       -e GETH_API_KEY={{ YOUR API KEY (OPTIONAL) }} \
       -e GETH_API_KEY_TYPE={{ HEADER NAME, e.g. x-goog-api-key or x-api-key (OPTIONAL) }} \
       -e INDEXER_START_HEIGHT=0 \
-      -e DEFRADB_KEYRING_SECRET=devnet-secret \
+      -e DEFRADB_KEYRING_SECRET=testnet-secret \
       -e DEFRADB_PLAYGROUND=true \
       -e DEFRADB_P2P_ENABLED=true \
       -e DEFRADB_P2P_LISTEN_ADDR=/ip4/0.0.0.0/tcp/9171 \

--- a/content/generator/register/index.md
+++ b/content/generator/register/index.md
@@ -12,7 +12,7 @@ If you are registering as a **Generator**, registration requires an [assertion](
 1. Start your Generator Client.
 1. Add the Shinzo Testnet to your browser wallet with the following values:
    - Network name: `Shinzo`
-   - Default RPC URL: `http://rpc.devnet.shinzo.network:8545`
+   - Default RPC URL: `http://rpc.testnet.shinzo.network:8545`
    - Chain ID: `91273002`
    - Currency symbol: `SHNZ`
 1. Go to the [Technical Registry](http://localhost:8080/registration-app) and connect your wallet using the button in the top-right corner.

--- a/content/guides/operator-quickstart/index.md
+++ b/content/guides/operator-quickstart/index.md
@@ -69,7 +69,7 @@ docker run -d \
   -e GETH_WS_URL="$GETH_WS_URL" \
   -e GETH_API_KEY="$GETH_API_KEY" \
   -e INDEXER_START_HEIGHT=0 \
-  -e DEFRADB_KEYRING_SECRET=devnet-secret \
+  -e DEFRADB_KEYRING_SECRET=testnet-secret \
   -e DEFRADB_PLAYGROUND=true \
   -e DEFRADB_P2P_ENABLED=true \
   -e DEFRADB_P2P_LISTEN_ADDR=/ip4/0.0.0.0/tcp/9171 \
@@ -80,7 +80,7 @@ docker run -d \
   ghcr.io/shinzonetwork/shinzo-generator-client:standard
 ```
 
-`DEFRADB_KEYRING_SECRET` is the password that protects the Generator client's signing key. The Generator client uses this key to sign every document it produces, which gives downstream consumers a way to verify the data came from a real Generator client. The `devnet-secret` password is fine for this quickstart, but remember use something more secure for anything in a production environment.
+`DEFRADB_KEYRING_SECRET` is the password that protects the Generator client's signing key. The Generator client uses this key to sign every document it produces, which gives downstream consumers a way to verify the data came from a real Generator client. The `testnet-secret` password is fine for this quickstart, but remember use something more secure for anything in a production environment.
 
 `DEFRADB_P2P_LISTEN_ADDR` tells DefraDB which interface and port to bind libp2p to inside the container. Binding to `0.0.0.0:9171` means the Host container, running on the same Docker bridge, can reach it.
 
@@ -146,7 +146,7 @@ The Host client reads its configuration from a YAML file mounted into the contai
 ```shell
 defradb:
   url: "localhost:9181"
-  keyring_secret: "host-devnet-secret"
+  keyring_secret: "host-testnet-secret"
   p2p:
     enabled: true
     bootstrap_peers:
@@ -156,7 +156,7 @@ defradb:
   store:
     path: "./.defra"
 shinzo:
-  hub_base_url: rpc.devnet.shinzo.network:26657
+  hub_base_url: rpc.testnet.shinzo.network:26657
   minimum_attestations: 1
   start_height: 0
 logger:

--- a/content/hosts/quickstart/index.md
+++ b/content/hosts/quickstart/index.md
@@ -136,7 +136,7 @@ More query examples are available [here](/hosts/examples/).
 
 ## VM Deployment
 
-This is the recommended approach for production and devnet participation. It uses Docker, docker-compose, and Nginx on a virtual machine.
+This is the recommended approach for production and testnet participation. It uses Docker, docker-compose, and Nginx on a virtual machine.
 
 ### Prerequisites
 
@@ -185,7 +185,7 @@ defradb:
   store:
     path: "./.defra"
 shinzo:
-  hub_base_url: rpc.devnet.shinzo.network:26657
+  hub_base_url: rpc.testnet.shinzo.network:26657
   minimum_attestations: 1
 logger:
   development: false
@@ -332,9 +332,9 @@ To participate in the Shinzo Network, you must register your Host. Registration 
 ### Option A: Register with the GUI
 
 1. Start your Host client.
-2. Add Shinzo Devnet to Metamask with the following values:
+2. Add Shinzo testnet to Metamask with the following values:
   - Network name: Shinzo
-  - Default RPC URL: http://rpc.devnet.shinzo.network:8545
+  - Default RPC URL: http://rpc.testnet.shinzo.network:8545
   - Chain ID: 91273002
   - Currency symbol: SHNZ
 3. Open the [registration route](http://localhost:8080/registration-app) and connect your wallet.
@@ -354,7 +354,7 @@ cast send "0x0000000000000000000000000000000000000211" \
   "<peer_id_signedMessage>" \
   "<signed_message>" \
   "1" \
-  --rpc-url "http://rpc.devnet.shinzo.network:8545" \
+  --rpc-url "http://rpc.testnet.shinzo.network:8545" \
   --from "<your_address>" \
   --private-key "<your_private_key>" \
   --gas-limit 100000

--- a/content/introduction/how-it-works/index.md
+++ b/content/introduction/how-it-works/index.md
@@ -53,7 +53,7 @@ On the app side, things look (surprisingly) normal. The app embeds DefraDB using
 
 #### Generator clients
 
-Generator clients are the entry point. Reserved for Ethereum validators at mainnet launch (and open to any node operator on devnet), they run as a sidecar to an existing execution client. Their only job is to read the chain, produce structured and signed primitives, and hand them off.
+Generator clients are the entry point. Reserved for Ethereum validators at mainnet launch (and open to any node operator on testnet), they run as a sidecar to an existing execution client. Their only job is to read the chain, produce structured and signed primitives, and hand them off.
 
 #### Hosts
 

--- a/content/reference/components/shinzohub/index.md
+++ b/content/reference/components/shinzohub/index.md
@@ -177,13 +177,14 @@ The path from user payment to access grant has four steps:
 
 ## Endpoints
 
-| Service | URL (devnet) |
+| Service | URL (testnet) |
 | --- | --- |
-| EVM JSON-RPC | `http://rpc.devnet.shinzo.network:8545` |
-| CometBFT RPC | `http://rpc.devnet.shinzo.network:26657` |
-| REST / LCD | `http://rpc.devnet.shinzo.network:1317` |
+| EVM JSON-RPC | `http://rpc.testnet.shinzo.network:8545` |
+| CometBFT RPC | `http://rpc.testnet.shinzo.network:26657` |
+| REST / LCD | `http://rpc.testnet.shinzo.network:1317` |
 | gRPC | port 9090 |
 
+<!--
 ## What is not implemented yet
 
 These appear in design docs but do not exist in any branch as of the current devnet:
@@ -194,3 +195,4 @@ These appear in design docs but do not exist in any branch as of the current dev
 - `GrantAccess` IBC message (actual mechanism uses ICA with ACP policy commands).
 - Direct outpost integration in ShinzoHub (the relayer bridges everything).
 - Hosts listening to SourceHub events (hosts listen to ShinzoHub CometBFT RPC, not SourceHub).
+-->

--- a/content/reference/components/viewkit/index.md
+++ b/content/reference/components/viewkit/index.md
@@ -68,10 +68,10 @@ viewkit view inspect my-usdc-view
 # Generate a wallet for deployments
 viewkit wallet generate
 
-# Deploy to devnet
+# Deploy to testnet
 viewkit view deploy my-usdc-view \
-  --target devnet \
-  --rpc http://rpc.devnet.shinzo.network:8545
+  --target testnet \
+  --rpc http://rpc.testnet.shinzo.network:8545
 ```
 
 ## What happens during deploy

--- a/content/reference/tools/index.md
+++ b/content/reference/tools/index.md
@@ -14,8 +14,8 @@ A reference list of web interfaces and endpoints for the Shinzo network.
 
 ## RPC Endpoints
 
-- `https://rpc.develop.devnet.shinzo.network:8545/`
-- `wss://rpc.develop.devnet.shinzo.network:8545/`
+- `http://rpc.testnet.shinzo.network:8545/`
+- `wss://rpc.testnet.shinzo.network:8545/`
 
 ## Developer Tools
 

--- a/content/views/overview/index.md
+++ b/content/views/overview/index.md
@@ -17,7 +17,7 @@ Within the Shinzo ecosystem, View Creator sits above the Generator client and al
 - View Creator → defines how that data should be queried, transformed, and exposed
 - Host clients → executes those definitions, serves results, and attests to correctness
 
-Using View Creator, developers write **Views** as versioned bundles that describe a complete data pipeline. These views are then deployed to a target environment (local, devnet, or future networks), where Hosts execute them deterministically against indexed data and serve the results to consumers.
+Using View Creator, developers write **Views** as versioned bundles that describe a complete data pipeline. These views are then deployed to a target environment (local, testnet, or future networks), where Hosts execute them deterministically against indexed data and serve the results to consumers.
 
 This separation enables:
 
@@ -47,7 +47,7 @@ View Creator is distributed as a CLI and is designed for local-first development
 - Incrementally adding queries, schemas, and lenses
 - Executing lenses locally for validation and preview
 - Deploying views to a local DefraDB instance with a GraphQL Playground
-- Signing and publishing views to shared networks like devnet
+- Signing and publishing views to shared networks like testnet
 
 By providing strong defaults, explicit versioning, and deterministic behavior, View Creator enables developers to focus on data semantics and transformations, while Shinzo handles execution, distribution, and verification.
 

--- a/content/views/quickstart/index.md
+++ b/content/views/quickstart/index.md
@@ -155,7 +155,7 @@ Viewkit revolves around **views**. Each view is a bundle that includes:
 - **SDL (GraphQL)** – how that data is modeled/exposed  
   (for example: `type FilteredAndDecodedLogs { transactionHash: String }`)
 - **Lenses (WASM)** – chained transforms that filter/decode/reshape data
-- **Wallet** – key used to sign deployments to a target network (`local`, `devnet`, etc.)
+- **Wallet** – key used to sign deployments to a target network (`local`, `testnet`, etc.)
 
 Think of the pipeline as:
 
@@ -172,7 +172,7 @@ We’ll walk end-to-end through an example view named **`testdeploy`**:
 5. Attach a lens
 6. Generate a wallet
 7. Deploy locally (with DefraDB Playground)
-8. Deploy to devnet
+8. Deploy to testnet
 
 > All commands assume `viewkit` is on your PATH.  
 > If not, replace `viewkit` with `./build/viewkit`.
@@ -279,7 +279,7 @@ If you see `libwasmer.dylib` / “image not found” errors, revisit the Wasmer 
 
 ## 7. Wallet: create a deployment key
 
-You need a wallet to sign deployments to `local` and `devnet`.
+You need a wallet to sign deployments to `local` and `testnet`.
 
 Generate one:
 
@@ -301,7 +301,7 @@ Treat it like any other wallet:
 
 ## 8. Deploy locally with `--target local`
 
-The recommended flow is to deploy **locally** first, verify the view in a Playground, then deploy to a shared network like `devnet`.
+The recommended flow is to deploy **locally** first, verify the view in a Playground, then deploy to a shared network like `testnet`.
 
 Deploy to local:
 
@@ -370,27 +370,27 @@ To iterate:
 
 - Refresh the Playground and test again.
 
-## 9. Deploy to devnet with `--target devnet`
+## 9. Deploy to testnet with `--target testnet`
 
-Once your view behaves correctly locally, you can deploy it to **devnet**.
+Once your view behaves correctly locally, you can deploy it to **testnet**.
 
 Make sure:
 
 - A wallet has been generated: `viewkit wallet generate`
-- Any required devnet config/credentials are set
+- Any required testnet config/credentials are set
 
 Then:
 
 ```bash
-viewkit view deploy testdeploy --target devnet --rpc http://shinzohub-rpc.infra.source.network:8545
+viewkit view deploy testdeploy --target testnet --rpc http://rpc.testnet.shinzo.network:8545
 ```
 
 Conceptually:
 
 1. Viewkit bundles the `testdeploy` view definition (queries, SDL, lenses, metadata).
 2. Signs a deployment transaction using your wallet.
-3. Sends it to the `devnet` network.
-4. Registers the view on devnet so it can be used and queried there.
+3. Sends it to the `testnet` network.
+4. Registers the view on testnet so it can be used and queried there.
 
 On success, you should see:
 
@@ -400,7 +400,7 @@ On success, you should see:
 If it fails:
 
 - Confirm your wallet is present and funded (if required)
-- Confirm `devnet` is a valid target
+- Confirm `testnet` is a valid target
 - Re-check the view definition with `viewkit view inspect testdeploy`
 
 ## 10. Full flow cheat sheet
@@ -446,8 +446,8 @@ viewkit view deploy testdeploy --target local
 # -> follow the printed URL (e.g. http://127.0.0.1:9181/) for the GraphQL Playground
 # -> press Ctrl+C in the terminal to stop
 
-# 8) once you're happy, deploy to devnet
-viewkit view deploy testdeploy --target devnet --rpc http://rpc.devnet.shinzo.network:8545
+# 8) once you're happy, deploy to testnet
+viewkit view deploy testdeploy --target testnet --rpc http://rpc.testnet.shinzo.network:8545
 ```
 
-This gives you a clean path from **GitHub clone** to a **locally tested view** and then to a **devnet deployment**.
+This gives you a clean path from **GitHub clone** to a **locally tested view** and then to a **testnet deployment**.


### PR DESCRIPTION
## Closes #269 and #265

## Summary

- Remove devnet instances
- Standardize the testnet RPC endpoints
- Create summary for what's coming in testnet